### PR TITLE
Use FontRenderer.listFormattedStringToWidth to cut lines

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/client/gui/journal/page/JournalPageText.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/gui/journal/page/JournalPageText.java
@@ -56,23 +56,7 @@ public class JournalPageText implements IJournalPage {
             String text = I18n.format(unlocText);
             List<String> lines = new LinkedList<>();
             for (String segment : text.split("<NL>")) {
-                StringBuilder cache = new StringBuilder();
-                for(String element : segment.split(" ")) {
-                    String cacheStr = cache.toString();
-                    String built = cacheStr.isEmpty() ? element : cacheStr + " " + element;
-                    if(fontRenderer.getStringWidth(built) > DEFAULT_WIDTH) {
-                        lines.add(cacheStr);
-                        cache = new StringBuilder();
-                        cache.append(element);
-                    } else {
-                        if(cacheStr.isEmpty()) {
-                            cache.append(element);
-                        } else {
-                            cache.append(' ').append(element);
-                        }
-                    }
-                }
-                lines.add(cache.toString());
+                lines.addAll(fontRenderer.listFormattedStringToWidth(segment, DEFAULT_WIDTH));
                 lines.add("");
             }
             return lines;


### PR DESCRIPTION
The previous implementation made the assumption that the translated text use space as word divider (e.g. any languages that use Latin alphabets), which is not the case for [writing system that rarely use whitespace as word divider](https://en.wikipedia.org/wiki/Word_divider#None), e.g. Chinese and Japanese. 
Thus here is the pull request. Using `FontRendererObj.listFormattedStringToWidth` has two advantages:
1. Shorter code & avoiding reinventing wheel;
2. can handle more rare cases, like the situation described above.