### PR TITLE
Use FontRenderer.listFormattedStringToWidth to cut lines, targeting 1.10.2 branch

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/client/gui/journal/page/JournalPageText.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/gui/journal/page/JournalPageText.java
@@ -56,23 +56,7 @@ public class JournalPageText implements IJournalPage {
             String text = I18n.format(unlocText);
             List<String> lines = new LinkedList<>();
             for (String segment : text.split("<NL>")) {
-                StringBuilder cache = new StringBuilder();
-                for(String element : segment.split(" ")) {
-                    String cacheStr = cache.toString();
-                    String built = cacheStr.isEmpty() ? element : cacheStr + " " + element;
-                    if(fontRenderer.getStringWidth(built) > DEFAULT_WIDTH) {
-                        lines.add(cacheStr);
-                        cache = new StringBuilder();
-                        cache.append(element);
-                    } else {
-                        if(cacheStr.isEmpty()) {
-                            cache.append(element);
-                        } else {
-                            cache.append(' ').append(element);
-                        }
-                    }
-                }
-                lines.add(cache.toString());
+                lines.addAll(fontRenderer.listFormattedStringToWidth(segment, DEFAULT_WIDTH));
                 lines.add("");
             }
             return lines;


### PR DESCRIPTION
Cherry picked from commit a1644bed808414e827985cc495ed6fea8c49e6a9 (i.e. #77) and targeting `1.10.2` branch. More details can be found in #77.