### PR TITLE
Fix PatchModifyEnchantmentLevelsTooltipEvent Crash

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/core/patch/helper/PatchModifyEnchantmentLevelsTooltipEvent.java
+++ b/src/main/java/hellfirepvp/astralsorcery/core/patch/helper/PatchModifyEnchantmentLevelsTooltipEvent.java
@@ -9,6 +9,7 @@
 package hellfirepvp.astralsorcery.core.patch.helper;
 
 import hellfirepvp.astralsorcery.core.ClassPatch;
+import net.minecraftforge.fml.relauncher.Side;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
 
@@ -54,5 +55,9 @@ public class PatchModifyEnchantmentLevelsTooltipEvent extends ClassPatch {
         mn.instructions.insertBefore(n, new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraftforge/fml/common/eventhandler/EventBus", "post", "(Lnet/minecraftforge/fml/common/eventhandler/Event;)Z", false));
         mn.instructions.insertBefore(n, new InsnNode(Opcodes.POP));
     }
-
+    
+    @Override
+    public boolean canExecuteForSide(Side side) {
+        return side == Side.CLIENT;
+    }
 }


### PR DESCRIPTION
Fix a server only startup crash with PatchModifyEnchantmentLevelsTooltipEvent.
It's likely getTooltip/func_82840_a only exists on the client side.

Found it when compiling the latest sources to get around #702 since its not in a released version yet.