### PR TITLE
Add Math.abs to activeDay calculation. Fixes #769

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/common/constellation/distribution/WorldSkyHandler.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/constellation/distribution/WorldSkyHandler.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.lang.Math;
 
 /**
  * This class is part of the Astral Sorcery Mod
@@ -187,7 +188,7 @@ public class WorldSkyHandler {
         activeConstellations.clear();
         activeDistributions.clear();
 
-        int activeDay = lastRecordedDay % 8;
+        int activeDay = Math.abs(lastRecordedDay % 8);
         LinkedList<IConstellation> linkedConstellations = initialValueMappings.computeIfAbsent(activeDay, day -> new LinkedList<>());
         for (int i = 0; i < Math.min(10, linkedConstellations.size()); i++) {
             activeConstellations.addLast(linkedConstellations.get(i));


### PR DESCRIPTION
In rare cases where the world day is a negative value for some reason, this will cause a infinite loop as the activeDay is a negative value, causing the dayDistributionMap lookup to always return null.