### PR TITLE
Right clicking on search inputs in perk/fragment search clears the field

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiJournalKnowledgeIndex.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiJournalKnowledgeIndex.java
@@ -56,6 +56,8 @@ public class GuiJournalKnowledgeIndex extends GuiScreenJournal {
     private static final int entriesLeft = 15;
     private static final int entriesRight = 14;
     private static final Random rand = new Random();
+    
+    private static Rectangle rectSearchTextEntry = new Rectangle(300, 20, 88, 15);
 
     private Rectangle rectNext, rectPrev;
     private KnowledgeFragment lastRenderHover = null;
@@ -242,6 +244,15 @@ public class GuiJournalKnowledgeIndex extends GuiScreenJournal {
         GlStateManager.color(1F, 1F, 1F, 1F);
 
         TextureHelper.refreshTextureBindState();
+    }
+
+    @Override
+    protected boolean handleRightClickClose(int mouseX, int mouseY) {
+        if (rectSearchTextEntry.contains(mouseX - guiLeft, mouseY - guiTop)) {
+            searchTextEntry.setText("");
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiJournalPerkTree.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiJournalPerkTree.java
@@ -78,6 +78,7 @@ public class GuiJournalPerkTree extends GuiScreenJournal {
     private static final AbstractRenderableTexture textureSearchMark = SpriteLibrary.spriteHalo4;
 
     private static Rectangle rectSealBox = new Rectangle(29, 16, 16, 16);
+    private static Rectangle rectSearchTextEntry = new Rectangle(300, 16, 88, 15);
 
     private SizeHandler sizeHandler;
     private GuiRenderBoundingBox guiBox;
@@ -924,6 +925,10 @@ public class GuiJournalPerkTree extends GuiScreenJournal {
 
     @Override
     protected boolean handleRightClickClose(int mouseX, int mouseY) {
+        if (rectSearchTextEntry.contains(mouseX - guiLeft, mouseY - guiTop)) {
+            searchTextEntry.setText("");
+            return true;
+        }
         if (socketMenu != null &&
                 rSocketMenu != null &&
                 !rSocketMenu.contains(mouseX, mouseY)) {


### PR DESCRIPTION
Small QoL thing that also makes habits of trying to clear search like in JEI not close the GUI. Tested on all GUI scales, works entirely as expected - right click anywhere on the field, it is cleared, otherwise the tome screen is closed.