### PR TITLE
Fixed NBT mismatch with recipes

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/common/CommonProxy.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/CommonProxy.java
@@ -168,6 +168,8 @@ public class CommonProxy implements IGuiHandler {
         } else {
             AstralSorcery.log.info("Crafttweaker not found!");
         }
+        
+        MinecraftForge.EVENT_BUS.register(PlayerAmuletHandler.INSTANCE); //AttachCapabilitiesEvent handler for ItemStacks should be registered in preInit, otherwise this will cause NBT mistmatch with ItemStacks from recipes
     }
 
     private void registerCapabilities() {
@@ -262,7 +264,7 @@ public class CommonProxy implements IGuiHandler {
         MinecraftForge.EVENT_BUS.register(EventHandlerCapeEffects.INSTANCE);
         MinecraftForge.EVENT_BUS.register(TimeStopController.INSTANCE);
         MinecraftForge.EVENT_BUS.register(FluidRarityRegistry.INSTANCE);
-        MinecraftForge.EVENT_BUS.register(PlayerAmuletHandler.INSTANCE);
+        //MinecraftForge.EVENT_BUS.register(PlayerAmuletHandler.INSTANCE);
         MinecraftForge.EVENT_BUS.register(PerkEffectHelper.EVENT_INSTANCE);
         MinecraftForge.EVENT_BUS.register(AttributeTypeLimiter.INSTANCE);
         MinecraftForge.EVENT_BUS.register(PlayerActivityManager.INSTANCE);


### PR DESCRIPTION
Ok, here is my final attempt to convince you. **Please** make sure to read everything and just try it, ok?

You have a handler for `AttachCapabilitiesEvent<ItemStack>` in `PlayerAmuletHandler.java` and you're registering that file in Minecraft `EVENT_BUS` in the `init` stage.
While event-related stuff is correct in the `init` stage (according to [ForgeDocs](https://mcforge.readthedocs.io/en/latest/conventions/loadstages/)), you can see that Capability-related stuff (both capability **and** event handler registration) should occur in the `preInit`.

Now I'll try to explain why this is so imporant when we're talking about `ItemStack`s:
In [this ForgeDocs](https://mcforge.readthedocs.io/en/latest/concepts/registries/#registering-things) article you can see that

> The recommended way to register things (items, blocks, recipes) is through the RegistryEvents. These events are fired right after preinitialization

So we have following order:

1. preInit
2. Items are being added
3. Recipes are being added
4. init - you're registering `AttachCapabilitiesEvent<ItemStack>` handler

Because of the current order, your handler will not apply your Capability to the `ItemStacks` that are used in Recipes.

Look, I tried to fork your project and build it with my changes. It **fixed** the issue.