### PR TITLE
Compatibility issue with structure blocks / Capsule Mod

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/common/starlight/transmission/TransmissionNetworkHelper.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/starlight/transmission/TransmissionNetworkHelper.java
@@ -117,6 +117,12 @@ public class TransmissionNetworkHelper {
         }
     }
 
+    public static boolean isTileInNetwork(TileNetwork tileNetwork) {
+        WorldNetworkHandler handler = WorldNetworkHandler.getNetworkHandler(tileNetwork.getWorld());
+        IPrismTransmissionNode node = handler.getTransmissionNode(tileNetwork.getPos());
+        return node != null;
+    }
+
     public static void informNetworkTilePlacement(TileNetwork tileNetwork) {
         WorldNetworkHandler handler = WorldNetworkHandler.getNetworkHandler(tileNetwork.getWorld());
         if(tileNetwork instanceof IStarlightSource) {

--- a/src/main/java/hellfirepvp/astralsorcery/common/tile/base/TileNetwork.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/tile/base/TileNetwork.java
@@ -22,11 +22,13 @@ import java.util.Random;
 public abstract class TileNetwork extends TileEntityTick {
 
     protected static final Random rand = new Random();
+    private boolean isNetworkInformed = false;
 
     public void update() {
         if(world.isRemote) return;
-        if(!TransmissionNetworkHelper.isTileInNetwork(this)) {
+        if(!isNetworkInformed && !TransmissionNetworkHelper.isTileInNetwork(this)) {
             TransmissionNetworkHelper.informNetworkTilePlacement(this);
+            isNetworkInformed = true;
         }
     }
 
@@ -38,6 +40,7 @@ public abstract class TileNetwork extends TileEntityTick {
     public void onBreak() {
         if(world.isRemote) return;
         TransmissionNetworkHelper.informNetworkTileRemoval(this);
+        isNetworkInformed = false;
     }
 
 }

--- a/src/main/java/hellfirepvp/astralsorcery/common/tile/base/TileNetwork.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/tile/base/TileNetwork.java
@@ -23,10 +23,16 @@ public abstract class TileNetwork extends TileEntityTick {
 
     protected static final Random rand = new Random();
 
+    public void update() {
+        if(world.isRemote) return;
+        if(!TransmissionNetworkHelper.isTileInNetwork(this)) {
+            TransmissionNetworkHelper.informNetworkTilePlacement(this);
+        }
+    }
+
     @Override
     protected void onFirstTick() {
-        if(world.isRemote) return;
-        TransmissionNetworkHelper.informNetworkTilePlacement(this);
+
     }
 
     public void onBreak() {


### PR DESCRIPTION
This pull request to follow discussion at https://github.com/HellFirePvP/AstralSorcery/issues/1108.

**Identified issue**
The TileNetwork class register itself (using `informNetworkTilePlacement`) to the Network based on its `tickExisted` nbt value. The `onFirstTick` method is called only when `ticksExisted == 0`. When the block is copied using /give command or a structure block, the `ticksExisted` value is kept and the block never register itself. Because it's not registered, it also print a stacktrace + warnings in console when removed, because the onBreak method to unregister (using `informNetworkTileRemoval`) is correctly called.

**higher-level consideration and suggested evolution**
The TileNetwork tries to register / unregister based on its own state, which makes it possible to desynchronise the network and the TileNetwork if any of the states (either the Network or the TileNetwork) changes.
A robust solution to this problem is to base registration not on self state but on the dependency state. Here it would be the TileEntity basing its registration on the Network state. My suggested evolution here is that the TileEntity constantly checks on the Network if it's already registered, and if not to register. This PR is an implementation proposition for this evolution.

**Additional notes**
I'm not able to test all cases related with this code because I'm still very new to the codebase. Please let me know if you think of possible undesirable (or desirable !) side effects so that I test the setups.