### PR TITLE
Partial fix for macOS disappearing cursor

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiHandTelescope.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiHandTelescope.java
@@ -14,6 +14,7 @@ import hellfirepvp.astralsorcery.client.gui.base.GuiSkyScreen;
 import hellfirepvp.astralsorcery.client.gui.base.GuiWHScreen;
 import hellfirepvp.astralsorcery.client.sky.RenderAstralSkybox;
 import hellfirepvp.astralsorcery.client.util.Blending;
+import hellfirepvp.astralsorcery.client.util.ClientUtils;
 import hellfirepvp.astralsorcery.client.util.RenderConstellation;
 import hellfirepvp.astralsorcery.client.util.RenderingUtils;
 import hellfirepvp.astralsorcery.client.util.TextureHelper;
@@ -128,7 +129,7 @@ public class GuiHandTelescope extends GuiWHScreen implements GuiSkyScreen {
         if (!Minecraft.IS_RUNNING_ON_MAC) {
             KeyBinding.updateKeyBindState();
         }
-        mc.mouseHelper.grabMouseCursor();
+        ClientUtils.grabMouseCursor();
         mc.inGameHasFocus = true;
     }
 
@@ -139,7 +140,7 @@ public class GuiHandTelescope extends GuiWHScreen implements GuiSkyScreen {
         if (!Minecraft.IS_RUNNING_ON_MAC) {
             KeyBinding.updateKeyBindState();
         }
-        mc.mouseHelper.grabMouseCursor();
+        ClientUtils.grabMouseCursor();
         mc.inGameHasFocus = true;
     }
 
@@ -193,13 +194,13 @@ public class GuiHandTelescope extends GuiWHScreen implements GuiSkyScreen {
             if(!Minecraft.IS_RUNNING_ON_MAC) {
                 KeyBinding.updateKeyBindState();
             }
-            Minecraft.getMinecraft().mouseHelper.grabMouseCursor();
+            ClientUtils.grabMouseCursor();
             Minecraft.getMinecraft().inGameHasFocus = true;
             grabCursor = false;
             clearLines();
         }
         if (!grabCursor && ctrl) {
-            Minecraft.getMinecraft().mouseHelper.ungrabMouseCursor();
+            ClientUtils.ungrabMouseCursor();
             Minecraft.getMinecraft().inGameHasFocus = false;
             grabCursor = true;
         }

--- a/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiObservatory.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiObservatory.java
@@ -127,7 +127,7 @@ public class GuiObservatory extends GuiTileBase<TileObservatory> implements GuiS
         if (!Minecraft.IS_RUNNING_ON_MAC) {
             KeyBinding.updateKeyBindState();
         }
-        mc.mouseHelper.grabMouseCursor();
+        ClientUtils.grabMouseCursor();
         mc.inGameHasFocus = true;
 
         mc.player.renderYawOffset = mc.player.rotationYawHead;
@@ -149,7 +149,7 @@ public class GuiObservatory extends GuiTileBase<TileObservatory> implements GuiS
         if (!Minecraft.IS_RUNNING_ON_MAC) {
             KeyBinding.updateKeyBindState();
         }
-        mc.mouseHelper.grabMouseCursor();
+        ClientUtils.grabMouseCursor();
         mc.inGameHasFocus = true;
     }
 
@@ -503,13 +503,13 @@ public class GuiObservatory extends GuiTileBase<TileObservatory> implements GuiS
             if(!Minecraft.IS_RUNNING_ON_MAC) {
                 KeyBinding.updateKeyBindState();
             }
-            Minecraft.getMinecraft().mouseHelper.grabMouseCursor();
+            ClientUtils.grabMouseCursor();
             Minecraft.getMinecraft().inGameHasFocus = true;
             grabCursor = false;
             clearLines();
         }
         if (!grabCursor && ctrl) {
-            Minecraft.getMinecraft().mouseHelper.ungrabMouseCursor();
+            ClientUtils.ungrabMouseCursor();
             Minecraft.getMinecraft().inGameHasFocus = false;
             grabCursor = true;
         }

--- a/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiSextantSelector.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/gui/GuiSextantSelector.java
@@ -177,7 +177,7 @@ public class GuiSextantSelector extends GuiWHScreen implements GuiSkyScreen {
         if (!Minecraft.IS_RUNNING_ON_MAC) {
             KeyBinding.updateKeyBindState();
         }
-        mc.mouseHelper.grabMouseCursor();
+        ClientUtils.grabMouseCursor();
         mc.inGameHasFocus = true;
     }
 
@@ -188,7 +188,7 @@ public class GuiSextantSelector extends GuiWHScreen implements GuiSkyScreen {
         if (!Minecraft.IS_RUNNING_ON_MAC) {
             KeyBinding.updateKeyBindState();
         }
-        mc.mouseHelper.grabMouseCursor();
+        ClientUtils.grabMouseCursor();
         mc.inGameHasFocus = true;
     }
 
@@ -538,12 +538,12 @@ public class GuiSextantSelector extends GuiWHScreen implements GuiSkyScreen {
             if(!Minecraft.IS_RUNNING_ON_MAC) {
                 KeyBinding.updateKeyBindState();
             }
-            Minecraft.getMinecraft().mouseHelper.grabMouseCursor();
+            ClientUtils.grabMouseCursor();
             Minecraft.getMinecraft().inGameHasFocus = true;
             grabCursor = false;
         }
         if (!grabCursor && ctrl) {
-            Minecraft.getMinecraft().mouseHelper.ungrabMouseCursor();
+            ClientUtils.ungrabMouseCursor();
             Minecraft.getMinecraft().inGameHasFocus = false;
             grabCursor = true;
         }

--- a/src/main/java/hellfirepvp/astralsorcery/client/util/ClientUtils.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/util/ClientUtils.java
@@ -8,6 +8,7 @@
 
 package hellfirepvp.astralsorcery.client.util;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
@@ -34,4 +35,15 @@ public class ClientUtils {
         }
     }
 
+    public static void grabMouseCursor() {
+        if (!Minecraft.IS_RUNNING_ON_MAC || !Mouse.isGrabbed()) {
+            Minecraft.getMinecraft().mouseHelper.grabMouseCursor();
+        }
+    }
+
+    public static void ungrabMouseCursor() {
+        if (!Minecraft.IS_RUNNING_ON_MAC || Mouse.isGrabbed()) {
+            Minecraft.getMinecraft().mouseHelper.ungrabMouseCursor();
+        }
+    }
 }

--- a/src/main/java/hellfirepvp/astralsorcery/client/util/RenderingUtils.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/util/RenderingUtils.java
@@ -481,9 +481,9 @@ public class RenderingUtils {
         render.rotationPitch =       (float)pitch;
         render.prevRotationPitch =   (float)pitchPrev;
 
-        Minecraft.getMinecraft().setIngameNotInFocus();
+        Minecraft.getMinecraft().inGameHasFocus = false;
         ActiveRenderInfo.updateRenderInfo(render, false);
-        Minecraft.getMinecraft().mouseHelper.grabMouseCursor();
+        ClientUtils.grabMouseCursor();
     }
 
     @Deprecated
@@ -507,14 +507,13 @@ public class RenderingUtils {
             if(Minecraft.getMinecraft().currentScreen != null) {
                 Minecraft.getMinecraft().displayGuiScreen(null);
             }
+
+            if (Display.isActive()) {
+                ClientUtils.ungrabMouseCursor();
+            }
+
             Minecraft.getMinecraft().inGameHasFocus = false;
             Minecraft.getMinecraft().setIngameFocus();
-
-            if (Minecraft.IS_RUNNING_ON_MAC) {
-                Mouse.setGrabbed(false);
-                Mouse.setCursorPosition(Display.getWidth() / 2, Display.getHeight() / 2);
-                Mouse.setGrabbed(true);
-            }
         }
     }
 


### PR DESCRIPTION
(Mostly) resolves #12 

The root of the problem is that LWJGL appears to have a bug on macOS where `Mouse.setGrabbed` calls must be evenly balanced between `true` and `false`.  It's most visible in AS due to manually grabbing the cursor while `Minecraft.inGameHasFocus` is false.

In order of preference, the solutions are:
1) Fix it in LWJGL and hope Mojang updates (unlikely).
2) Make a PR to Forge to include `if (!Mouse.isGrabbed())` calls etc. in `MouseHelper`.
3) Do a bandaid solution in Astral Sorcery that covers most cases.

I've opted for 3) as it's the easiest to implement for now.

Note that there are still some caveats due to Minecraft calling grab/ungrab after AS has manually forced it:

* Looking Glass, Sextant, and Observatory are fine as long as you don't task switch, since hitting escape or E will close the GUI.
* Attunement is fine if you don't task switch or bring up any kind of GUI (or the main menu) during the animation.  Essentially just don't touch the computer while attuning.

I'll look at making a PR to Forge (which will alleviate these caveats too), but this will hopefully keep macOS Astral Sorcery fans happy for the meantime.  😄 

~Edit: I have made a PR to Forge.~
Edit 2: Forge are no longer making changes to 1.12.2, so this may be the best we're going to get until 1.14.

https://github.com/MinecraftForge/MinecraftForge/pull/6183