### PR TITLE
Use ForgeRegistry for DataSerializers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ if (System.getenv("BUILD_NUMBER") != null) {
 }
 
 minecraft {
-    version = "1.12.2-14.23.5.2781"
+    version = "1.12.2-14.23.5.2847"
     runDir = "run"
     useDepAts = true
 

--- a/src/main/java/hellfirepvp/astralsorcery/common/CommonProxy.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/CommonProxy.java
@@ -147,7 +147,6 @@ public class CommonProxy implements IGuiHandler {
         RegistryItems.setupDefaults();
 
         RegistryConstellations.init();
-        ASDataSerializers.registerSerializers();
         RegistryAdvancements.init();
 
         PacketChannel.init();

--- a/src/main/java/hellfirepvp/astralsorcery/common/registry/internal/PrimerEventHandler.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/registry/internal/PrimerEventHandler.java
@@ -13,6 +13,7 @@ import hellfirepvp.astralsorcery.common.base.LightOreTransmutations;
 import hellfirepvp.astralsorcery.common.base.LiquidInteraction;
 import hellfirepvp.astralsorcery.common.base.WellLiquefaction;
 import hellfirepvp.astralsorcery.common.registry.*;
+import hellfirepvp.astralsorcery.common.util.ASDataSerializers;
 import net.minecraft.block.Block;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.item.Item;
@@ -22,6 +23,7 @@ import net.minecraft.util.SoundEvent;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.registries.DataSerializerEntry;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
@@ -95,6 +97,13 @@ public class PrimerEventHandler {
     public void registerSounds(RegistryEvent.Register<SoundEvent> event) {
         registry.wipe(event.getClass());
         RegistrySounds.init();
+        fillRegistry(event.getRegistry().getRegistrySuperType(), event.getRegistry());
+    }
+    
+    @SubscribeEvent
+    public void registerDataSerializers(RegistryEvent.Register<DataSerializerEntry> event) {
+        registry.wipe(event.getClass());
+        ASDataSerializers.registerSerializers();
         fillRegistry(event.getRegistry().getRegistrySuperType(), event.getRegistry());
     }
 

--- a/src/main/java/hellfirepvp/astralsorcery/common/util/ASDataSerializers.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/util/ASDataSerializers.java
@@ -8,12 +8,14 @@
 
 package hellfirepvp.astralsorcery.common.util;
 
+import hellfirepvp.astralsorcery.AstralSorcery;
+import hellfirepvp.astralsorcery.common.CommonProxy;
 import hellfirepvp.astralsorcery.common.util.data.Vector3;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializer;
-import net.minecraft.network.datasync.DataSerializers;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.registries.DataSerializerEntry;
 
 import java.io.IOException;
 
@@ -98,9 +100,9 @@ public class ASDataSerializers {
     };
 
     public static void registerSerializers() {
-        DataSerializers.registerSerializer(VECTOR);
-        DataSerializers.registerSerializer(FLUID);
-        DataSerializers.registerSerializer(LONG);
+        CommonProxy.registryPrimer.register(new DataSerializerEntry(ASDataSerializers.FLUID).setRegistryName(AstralSorcery.MODID, "serializer_fluid"));
+        CommonProxy.registryPrimer.register(new DataSerializerEntry(ASDataSerializers.LONG).setRegistryName(AstralSorcery.MODID, "serializer_long"));
+        CommonProxy.registryPrimer.register(new DataSerializerEntry(ASDataSerializers.VECTOR).setRegistryName(AstralSorcery.MODID, "serializer_vec3d"));
     }
 
 }


### PR DESCRIPTION
Potential fix for https://github.com/HellFirePvP/AstralSorcery/issues/1020 & https://github.com/HellFirePvP/AstralSorcery/issues/513

For more information: https://github.com/MinecraftForge/MinecraftForge/pull/5245
TL;DR Using Vanilla's method for DataSerializer registration is not safe as it doesn't guarantee that the packet ids will match on the client and server.