### PR TITLE
Fix Aevitas mantle draining starlight charge during survival flight

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/common/constellation/mantle/effect/MantleEffectAevitas.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/constellation/mantle/effect/MantleEffectAevitas.java
@@ -48,16 +48,18 @@ public class MantleEffectAevitas extends MantleEffect {
 
         World world = player.getEntityWorld();
         BlockPos playerPos = player.getPosition();
-        for (int xx = -3; xx <= 3; xx++) {
-            for (int zz = -3; zz <= 3; zz++) {
-                BlockPos at = playerPos.add(xx, -1, zz);
-                MiscUtils.executeWithChunk(world, at, () -> {
-                    if (world.getBlockState(at).isAir(world, at) && AlignmentChargeHandler.INSTANCE.hasCharge(player, LogicalSide.SERVER, CONFIG.chargeCostPerBlock.get())) {
-                        if (world.setBlockState(at, BlocksAS.VANISHING.getDefaultState())) {
-                            AlignmentChargeHandler.INSTANCE.drainCharge(player, LogicalSide.SERVER, CONFIG.chargeCostPerBlock.get(), false);
+        if (!player.abilities.isFlying){
+            for (int xx = -3; xx <= 3; xx++) {
+                for (int zz = -3; zz <= 3; zz++) {
+                    BlockPos at = playerPos.add(xx, -1, zz);
+                    MiscUtils.executeWithChunk(world, at, () -> {
+                        if (world.getBlockState(at).isAir(world, at) && AlignmentChargeHandler.INSTANCE.hasCharge(player, LogicalSide.SERVER, CONFIG.chargeCostPerBlock.get())) {
+                            if (world.setBlockState(at, BlocksAS.VANISHING.getDefaultState())) {
+                                AlignmentChargeHandler.INSTANCE.drainCharge(player, LogicalSide.SERVER, CONFIG.chargeCostPerBlock.get(), false);
+                            }
                         }
-                    }
-                });
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
This fixes the issue with the Aevitas mantle draining starlight charge during survival flight. A boolean has been added to the block placement loop, to ensure that no blocks are placed during flight. Any changes to this or suggestions are welcome, this is my first "official" PR.

[video log](https://imgur.com/XicfX1K)

EDIT: Derp, survival flight rather than creative flight.