### PR TITLE
Fix player model parts being skipped over during camera flight

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/client/util/camera/ClientCameraManager.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/util/camera/ClientCameraManager.java
@@ -25,7 +25,6 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;

--- a/src/main/java/hellfirepvp/astralsorcery/client/util/camera/ClientCameraManager.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/util/camera/ClientCameraManager.java
@@ -16,6 +16,7 @@ import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.settings.GameSettings;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EnumPlayerModelParts;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -24,6 +25,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -346,6 +348,13 @@ public class ClientCameraManager implements ITickHandler {
         public EntityClientReplacement() {
             super(Minecraft.getMinecraft().world, Minecraft.getMinecraft().player.getGameProfile());
         }
+
+        @SideOnly(Side.CLIENT)
+        @Override
+        public boolean isWearing(EnumPlayerModelParts part) {
+            return Minecraft.getMinecraft().player != null && Minecraft.getMinecraft().player.isWearing(part);
+        }
+
     }
 
 }


### PR DESCRIPTION
#1375 has been reproduced in AS 1.12.2, 1.10.28 while testing workspaces. That being said, a pull request has been made to fix the changes that were reflected on MC 1.15.2 to pass the model parts to the replaced client entity for the camera flight.

![javaw_5PxziH85pG](https://user-images.githubusercontent.com/9144208/95294086-a68c2c00-0842-11eb-9036-70590c939e39.png)
