### PR TITLE
Fix player model parts being skipped over during camera flight

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/client/util/camera/ClientCameraManager.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/util/camera/ClientCameraManager.java
@@ -16,6 +16,7 @@ import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.settings.GameSettings;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EnumPlayerModelParts;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -346,6 +347,13 @@ public class ClientCameraManager implements ITickHandler {
         public EntityClientReplacement() {
             super(Minecraft.getMinecraft().world, Minecraft.getMinecraft().player.getGameProfile());
         }
+
+        @SideOnly(Side.CLIENT)
+        @Override
+        public boolean isWearing(EnumPlayerModelParts part) {
+            return Minecraft.getMinecraft().player != null && Minecraft.getMinecraft().player.isWearing(part);
+        }
+
     }
 
 }


### PR DESCRIPTION
Duplicate of #1407, sorry for the mess. I made an accidental mistake when working with my local branches; organizing it as much as I can.