### PR TITLE
Fix tree beacon loot table from datagen run

### DIFF
--- a/src/main/resources/data/astralsorcery/loot_tables/blocks/tree_beacon.json
+++ b/src/main/resources/data/astralsorcery/loot_tables/blocks/tree_beacon.json
@@ -6,7 +6,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:air"
+          "name": "astralsorcery:tree_beacon"
         }
       ],
       "conditions": [


### PR DESCRIPTION
Fixes #1436, no changes to the datagen code were made. There are also additional changes from the output of the datagen, but I don't think they show any possible relevant issues, so only the tree beacon output is included with this PR.

![image](https://user-images.githubusercontent.com/9144208/98314660-769c8980-1fa4-11eb-943f-906e2c29797f.png)


