### PR TITLE
Botania integration for block provision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ minecraft {
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'info'
+            
+            // Required for Botania mixins to not crash terribly
+            property 'mixin.env.disableRefMap', 'true'
 
             mods {
                 astralsorcery {
@@ -61,6 +64,9 @@ minecraft {
 
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'info'
+            
+            // Required for Botania mixins to not crash terribly
+            property 'mixin.env.disableRefMap', 'true'
 
             mods {
                 astralsorcery {
@@ -105,6 +111,11 @@ repositories {
         name 'JEI maven'
         url "https://dvs1.progwml6.com/files/maven"
     }
+    
+    maven {
+        name 'Botania maven'
+        url "https://maven.blamejared.com"
+    }
 
 }
 
@@ -115,12 +126,17 @@ dependencies {
     compileOnly 'hellfirepvp.observerlib:observerlib:1.16.4-1.4.4.v72'
     runtimeOnly 'hellfirepvp.observerlib:observerlib:1.16.4-1.4.4.v72:deobf'
 
-    compileOnly 'top.theillusivec4.curios:curios-forge:1.16.4-4.0.2.1:api'
-    runtimeOnly fg.deobf('top.theillusivec4.curios:curios-forge:1.16.4-4.0.2.1')
+    compileOnly 'top.theillusivec4.curios:curios-forge:1.16.4-4.0.3.0:api'
+    runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.16.4-4.0.3.0")
 
     compileOnly fg.deobf('mezz.jei:jei-1.16.4:7.6.0.58')
     runtimeOnly fg.deobf('mezz.jei:jei-1.16.4:7.6.0.58')
 
+    compileOnly fg.deobf("vazkii.patchouli:Patchouli:1.16.4-48:api")
+    runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:1.16.4-48")
+    
+    compileOnly fg.deobf("vazkii.botania:Botania:1.16.4-410:api")
+    runtimeOnly fg.deobf("vazkii.botania:Botania:1.16.4-410")
 }
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/hellfirepvp/astralsorcery/common/integration/IntegrationBotania.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/integration/IntegrationBotania.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * HellFirePvP / Astral Sorcery 2020
+ *
+ * All rights reserved.
+ * The source code is available on github: https://github.com/HellFirePvP/AstralSorcery
+ * For further details, see the License file there.
+ ******************************************************************************/
+
+package hellfirepvp.astralsorcery.common.integration;
+
+import hellfirepvp.astralsorcery.common.util.item.ItemUtils;
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+
+import vazkii.botania.api.item.IBlockProvider;
+
+import java.util.*;
+
+/**
+ * This class is part of the Astral Sorcery Mod
+ * The complete source code for this mod can be found on github.
+ * Class: IntegrationBotania
+ * Created by Penrif
+ * Date: 12.26.2020 / 16:45
+ */
+public class IntegrationBotania {
+    
+    public static Collection<ItemStack> botaniaFindItemsInPlayerInventory(PlayerEntity player, ItemStack match) {
+        List<ItemStack> stacksOut = new LinkedList<>();
+
+        // Botania can only supply blocks, so let's filter that out first.
+        if(!(match.getItem() instanceof BlockItem)) {
+            return stacksOut;
+        }
+
+        Block matchBlock = ((BlockItem) match.getItem()).getBlock();
+
+        IItemHandler handler = player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).orElse(ItemUtils.EMPTY_INVENTORY);
+        for (int j = 0; j < handler.getSlots(); j++) {
+            ItemStack s = handler.getStackInSlot(j);
+            Item sItem = s.getItem();
+            if (sItem instanceof IBlockProvider) {
+                IBlockProvider provider = (IBlockProvider) sItem;
+                int blockCount = provider.getBlockCount(player, s, s, matchBlock);
+                if (blockCount == -1) {
+                    // Used by rods to indicate infinite.  That doesn't suit our needs, so let's just report a lot.
+                    blockCount = 9001;
+                }
+                if (blockCount > 0) {
+                    stacksOut.add(ItemUtils.copyStackWithSize(s, blockCount));
+                }
+            }
+        }
+        return stacksOut;
+    }
+    
+    public static boolean consumeFromPlayerInventory(PlayerEntity player, ItemStack requestingItemStack, ItemStack toConsume, boolean simulate) {
+
+        // Botania can only supply blocks, so let's filter that out first.
+        if (!(toConsume.getItem() instanceof BlockItem)) {
+            return false;
+        }
+
+        Block consumeBlock = ((BlockItem) toConsume.getItem()).getBlock();
+        IItemHandler handler = player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).orElse(ItemUtils.EMPTY_INVENTORY);
+        for (int j = 0; j < handler.getSlots(); j++) {
+            ItemStack s = handler.getStackInSlot(j);
+            Item sItem = s.getItem();
+            if (sItem instanceof IBlockProvider) {
+                IBlockProvider provider = (IBlockProvider) sItem;
+                int blockCount = provider.getBlockCount(player, s, s, consumeBlock);
+                if (blockCount == -1 || blockCount > toConsume.getCount()) {
+                    // -1 is used by rods to indicate infinite.  Not technically true, but until Botania sorts out how to report how many invocations the player's
+                    // mana can handle, we'll have to take it at its word.
+                    // It also doesn't take mana availability into account until actually invoked to fully commit, so best we can do is eat up
+                    // as much as we have, and if it wasn't enough, say sorry and fail the entire operation.
+                    if (!simulate) {
+                        for (int i = 0; i < toConsume.getCount(); i++) {
+                            if (!provider.provideBlock(player, s, s, consumeBlock, true)) {
+                                return false;
+                            }
+                        }
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/hellfirepvp/astralsorcery/common/item/wand/ItemArchitectWand.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/item/wand/ItemArchitectWand.java
@@ -200,20 +200,16 @@ public class ItemArchitectWand extends Item implements ItemBlockStorage, ItemOve
                 continue;
             }
 
-            if (MiscUtils.canPlayerPlaceBlockPos(player, stateToPlace, placePos, Direction.UP)) {
-                if (AlignmentChargeHandler.INSTANCE.drainCharge(player, LogicalSide.SERVER, COST_PER_PLACEMENT, false) &&
-                        world.setBlockState(placePos, stateToPlace)) {
-                    if (!player.isCreative()) {
-                        ItemUtils.consumeFromPlayerInventory(player, held, extractable, false);
-                    }
-
-                    PktPlayEffect ev = new PktPlayEffect(PktPlayEffect.Type.BLOCK_EFFECT)
-                            .addData(buf -> {
-                                ByteBufUtils.writePos(buf, placePos);
-                                ByteBufUtils.writeBlockState(buf, stateToPlace);
-                            });
-                    PacketChannel.CHANNEL.sendToAllAround(ev, PacketChannel.pointFromPos(world, placePos, 32));
-                }
+            if (MiscUtils.canPlayerPlaceBlockPos(player, stateToPlace, placePos, Direction.UP) &&
+                    (player.isCreative() || ItemUtils.consumeFromPlayerInventory(player, held, extractable, false)) &&
+                    AlignmentChargeHandler.INSTANCE.drainCharge(player, LogicalSide.SERVER, COST_PER_PLACEMENT, false) &&
+                    world.setBlockState(placePos, stateToPlace)) {
+                PktPlayEffect ev = new PktPlayEffect(PktPlayEffect.Type.BLOCK_EFFECT)
+                        .addData(buf -> {
+                            ByteBufUtils.writePos(buf, placePos);
+                            ByteBufUtils.writeBlockState(buf, stateToPlace);
+                        });
+                PacketChannel.CHANNEL.sendToAllAround(ev, PacketChannel.pointFromPos(world, placePos, 32));
             }
         }
         return ActionResult.resultSuccess(held);

--- a/src/main/java/hellfirepvp/astralsorcery/common/item/wand/ItemExchangeWand.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/item/wand/ItemExchangeWand.java
@@ -211,22 +211,17 @@ public class ItemExchangeWand extends Item implements ItemBlockStorage, ItemOver
             }
 
             BlockState prevState = world.getBlockState(placePos);
-            if (((ServerPlayerEntity) player).interactionManager.tryHarvestBlock(placePos)) {
-                if (MiscUtils.canPlayerPlaceBlockPos(player, stateToPlace, placePos, Direction.UP)) {
-                    if (AlignmentChargeHandler.INSTANCE.drainCharge(player, LogicalSide.SERVER, COST_PER_EXCHANGE, false) &&
-                            world.setBlockState(placePos, stateToPlace)) {
-                        if (!player.isCreative()) {
-                            ItemUtils.consumeFromPlayerInventory(player, stack, extractable, false);
-                        }
-
-                        PktPlayEffect ev = new PktPlayEffect(PktPlayEffect.Type.BLOCK_EFFECT)
-                                .addData(buf -> {
-                                    ByteBufUtils.writePos(buf, placePos);
-                                    ByteBufUtils.writeBlockState(buf, prevState);
-                                });
-                        PacketChannel.CHANNEL.sendToAllAround(ev, PacketChannel.pointFromPos(world, placePos, 32));
-                    }
-                }
+            if ((player.isCreative() || ItemUtils.consumeFromPlayerInventory(player, stack, extractable, false)) &&
+                    AlignmentChargeHandler.INSTANCE.drainCharge(player, LogicalSide.SERVER, COST_PER_EXCHANGE, false) &&
+                    ((ServerPlayerEntity) player).interactionManager.tryHarvestBlock(placePos) &&
+                    MiscUtils.canPlayerPlaceBlockPos(player, stateToPlace, placePos, Direction.UP) &&
+                    world.setBlockState(placePos, stateToPlace)) {
+                PktPlayEffect ev = new PktPlayEffect(PktPlayEffect.Type.BLOCK_EFFECT)
+                        .addData(buf -> {
+                            ByteBufUtils.writePos(buf, placePos);
+                            ByteBufUtils.writeBlockState(buf, prevState);
+                        });
+                PacketChannel.CHANNEL.sendToAllAround(ev, PacketChannel.pointFromPos(world, placePos, 32));
             }
         }
 

--- a/src/main/java/hellfirepvp/astralsorcery/common/util/item/ItemUtils.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/util/item/ItemUtils.java
@@ -8,7 +8,9 @@
 
 package hellfirepvp.astralsorcery.common.util.item;
 
+import hellfirepvp.astralsorcery.common.base.Mods;
 import hellfirepvp.astralsorcery.common.util.tile.TileInventory;
+import hellfirepvp.astralsorcery.common.integration.IntegrationBotania;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -198,7 +200,14 @@ public class ItemUtils {
     }
 
     public static Collection<ItemStack> findItemsInPlayerInventory(PlayerEntity player, ItemStack match, boolean strict) {
-        return findItemsInInventory(player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).orElse(EMPTY_INVENTORY), match, strict);
+        IItemHandler handler = player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).orElse(EMPTY_INVENTORY);
+        Collection<ItemStack> results = findItemsInInventory(handler, match, strict);
+
+        if (Mods.BOTANIA.isPresent()) {
+            results.addAll(IntegrationBotania.botaniaFindItemsInPlayerInventory(player, match));
+        }
+
+        return results;
     }
 
     public static Collection<ItemStack> findItemsInInventory(IItemHandler handler, ItemStack match, boolean strict) {
@@ -239,7 +248,23 @@ public class ItemUtils {
     public static boolean consumeFromPlayerInventory(PlayerEntity player, ItemStack requestingItemStack, ItemStack toConsume, boolean simulate) {
         int consumed = 0;
         ItemStack tryConsume = copyStackWithSize(toConsume, toConsume.getCount() - consumed);
-        return tryConsume.isEmpty() || consumeFromInventory((IItemHandlerModifiable) player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).orElse(EMPTY_INVENTORY), tryConsume, simulate);
+
+        if (tryConsume.isEmpty()) {
+            return true;
+        }
+
+        IItemHandlerModifiable handler = (IItemHandlerModifiable) player.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).orElse(EMPTY_INVENTORY);
+        if (consumeFromInventory(handler, tryConsume, simulate)) {
+            return true;
+        }
+        
+        if (Mods.BOTANIA.isPresent()) {
+            if (IntegrationBotania.consumeFromPlayerInventory(player, requestingItemStack, toConsume, simulate)) {
+                return true;
+            }
+        }
+                
+        return false;
     }
 
     public static boolean tryConsumeFromInventory(IItemHandler handler, ItemStack toConsume, boolean simulate) {


### PR DESCRIPTION
 - Altered the logic of Exchange and Architect wands in order to account for consumeFromPlayerInventory possibly returning false.  Charge should not be consumed, nor should the world be edited in that case.
 - Added extensions to ItemUtils's findItemsInPlayerInventory and consumeFromPlayerInventory to be able to utilize Botania items implementing IBlockProvider - namely the dirt/cobble rods and the Black Hole Talisman.
 - Some hacks required as the rods in particular don't simulate true to how they action.  The simulated checks do not check for available mana, and querying for how many blocks can be made also does not account for that.  Might pop over to their repo to fix that, then come back to sweep up my mess if they accept the change...