### PR TITLE
Update NBTHelper.java

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/common/util/nbt/NBTHelper.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/util/nbt/NBTHelper.java
@@ -354,8 +354,9 @@ public class NBTHelper {
     }
 
     public static void removeUUID(CompoundNBT compound, String key) {
-        compound.remove(key + "Most");
-        compound.remove(key + "Least");
+        compound.remove(key);
+        // compound.remove(key + "Most");
+        // compound.remove(key + "Least");
     }
 
     public static UUID getUUID(CompoundNBT compoundNBT, String key, UUID _default) {


### PR DESCRIPTION
This fixes the tools, armour and weapons not removing the "AS_Amulet" nbt tage when being removed from main hand or equipped slot.