### PR TITLE
Add localization for game rule

### DIFF
--- a/src/main/resources/assets/astralsorcery/lang/en_us.json
+++ b/src/main/resources/assets/astralsorcery/lang/en_us.json
@@ -3,6 +3,8 @@
   "itemGroup.astralsorcery.papers": "[AS] Constellation Papers",
   "itemGroup.astralsorcery.crystals": "[AS] Attuned Crystals",
 
+  "gamerule.asIgnoreSkylightCheck": "Ignore Skylight Check (Astral Sorcery)",
+
   "astralsorcery.command.argument.constellation.notfound": "Constellation not found.",
 
   "death.attack.astralsorcery.stellar": "%1$s disintegrated into dust",


### PR DESCRIPTION
Localization for game rules is used in the Edit Game Rules screen during world creation

![Screenshot of the game rules screen with Astral Sorcery game rule](https://i.imgur.com/IuhUgrx.png)

The naming pattern `Name (Mod Name)` is based upon Immersive Portals' game rule

![Screenshot of the game rules screen with Immersive Portals game rule](https://i.imgur.com/Rm5lt9H.png)