### PR TITLE
Add compatibility with Lootr.

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/common/world/marker/MarkerManagerAS.java
+++ b/src/main/java/hellfirepvp/astralsorcery/common/world/marker/MarkerManagerAS.java
@@ -80,14 +80,11 @@ public class MarkerManagerAS {
 
     private static void makeChest(IWorld world, BlockPos pos, ResourceLocation tableName, Random rand, MutableBoundingBox box) {
         if (box.isVecInside(pos) && world.getBlockState(pos).getBlock() != Blocks.CHEST) {
-            BlockState chest = Blocks.CHEST.getDefaultState();
-            StructurePiece.correctFacing(world, pos, chest);
+            BlockState chest = StructurePiece.correctFacing(world, pos, Blocks.CHEST.getDefaultState());
 
             world.setBlockState(pos, chest, Constants.BlockFlags.BLOCK_UPDATE);
-            LockableLootTileEntity tile = MiscUtils.getTileAt(world, pos, LockableLootTileEntity.class, true);
-            if (tile != null) {
-                tile.setLootTable(tableName, rand.nextLong());
-            }
+            // Static setLootTable used instead of manual tile fetch -> member setLootTable to provide compatibility with Lootr.
+            LockableLootTileEntity.setLootTable(world, rand, pos, tableName);
         }
     }
 }


### PR DESCRIPTION
Lootr provides instanced loot chests for every player on the server. If a player opens a chest they've never opened before, it generates an inventory for them and stores it in WorldSavedData.

It primarily helps with multiplayer servers: people who are looking for loot don't go "oh empty chests/chest with rubbish in it" and then generating a bunch of chunks looking for loot.

Functionally, the only difference with this change to use `LockableLootTileEntity.setLootTable` (static version) and the previously used method is that it doesn't use your specific utility for fetching the tile entity.

On the plus side, it means that the hook (which can be mixed-in to) has the relevant world and information allowing for replacement of chests during generation without having to rely on externally snychronised (and buggy) ticking lists to try replacing after the chunk is generated.