### PR TITLE
Fix attunement camera hiccup

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/client/util/camera/ClientCameraUtil.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/util/camera/ClientCameraUtil.java
@@ -23,6 +23,12 @@ import net.minecraft.util.math.MathHelper;
 public class ClientCameraUtil {
 
     public static void positionCamera(PlayerEntity renderView, float pTicks, double x, double y, double z, double prevX, double prevY, double prevZ, double yaw, double yawPrev, double pitch, double pitchPrev) {
+        double dYaw = MathHelper.positiveModulo(yaw - yawPrev, 360d);
+        // Use the smaller arc
+        if (dYaw > 180) {
+            dYaw -= 360;
+        }
+        yawPrev = yaw - dYaw;
         float iYaw = MathHelper.lerp(pTicks, (float) yawPrev, (float) yaw);
         float iPitch = MathHelper.lerp(pTicks, (float) pitchPrev, (float) pitch);
 


### PR DESCRIPTION
When the `yaw` wraps around, the difference between the `yaw` and `prevYaw` is almost 360 degrees, which results in the `lerp` rapidly rotating the camera for a single game tick.

This PR makes it so that the smaller arc is used and adjusts the `prevYaw` value to facillitate this.

Feel free to put this code in a helper function somewhere (and close this PR) if that is preferred / cleaner.

Timestamped Videos (<1 min each):

[Before](https://www.youtube.com/watch?v=iA1y0500Pvs) (Occurs when camera is right behind the player.)

[After](https://www.youtube.com/watch?v=Vq9LRNNYKpY)

[After (Reversed)](https://www.youtube.com/watch?v=TJdqMe1skQ0) (To test that the code works for both directions.)