### PR TITLE
Fix Observatory Draw Area leak

### DIFF
--- a/src/main/java/hellfirepvp/astralsorcery/client/screen/ScreenObservatory.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/screen/ScreenObservatory.java
@@ -83,7 +83,7 @@ public class ScreenObservatory extends TileConstellationDiscoveryScreen<TileObse
     @Nonnull
     @Override
     protected List<DrawArea> createDrawAreas() {
-        return Lists.newArrayList(FullScreenDrawArea.INSTANCE);
+        return Lists.newArrayList(new FullScreenDrawArea());
     }
 
     @Override

--- a/src/main/java/hellfirepvp/astralsorcery/client/screen/telescope/FullScreenDrawArea.java
+++ b/src/main/java/hellfirepvp/astralsorcery/client/screen/telescope/FullScreenDrawArea.java
@@ -21,9 +21,7 @@ import java.awt.*;
  */
 public class FullScreenDrawArea extends ConstellationDiscoveryScreen.DrawArea {
 
-    public static final FullScreenDrawArea INSTANCE = new FullScreenDrawArea();
-
-    private FullScreenDrawArea() {
+    public FullScreenDrawArea() {
         super(new Rectangle());
     }
 


### PR DESCRIPTION
The single instance of `FullScreenDrawArea` used by `ScreenObservatory` resulted in constellations leaking between instances of `ScreenObservatory`.

This PR changes it to create a new `FullScreenDrawArea` each time.

To reproduce:

1. Open Observatory
2. Skip a night
3. Repeat 1 & 2 till constellations are overlapping or present when they should not be.

Feel free to close this PR for a better / alternative implementation e.g. clearing the area instead of instantiating a new one.

<details>
<summary>Screenshots (without this PR)</summary>

Pelotrio in the Observatory
![Pelotrio in the Observatory](https://user-images.githubusercontent.com/630920/113684624-01bab080-96f8-11eb-89d0-7e296f0fbd3f.png)

Not a Full Moon or New Moon
![Not a Full Moon or New Moon](https://user-images.githubusercontent.com/630920/113684666-0a12eb80-96f8-11eb-844f-66d6b3a580bd.png)
</details>
